### PR TITLE
Fixed COOK-2298 - webpi will not install anything due to logic bug

### DIFF
--- a/providers/product.rb
+++ b/providers/product.rb
@@ -42,7 +42,7 @@ private
 def installed?
   @installed ||= begin
     cmd = shell_out("#{webpicmd} /List /ListOption:Installed", {:returns => [0,42]})
-    cmd.stderr.empty? && cmd.stdout.lines.grep(/^#{@new_resource.product_id}\s.*$/i)
+    cmd.stderr.empty? && !cmd.stdout.lines.grep(/^#{@new_resource.product_id}\s.*$/i).empty?
   end
 end
 


### PR DESCRIPTION
Fixed COOK-2298 - webpi will not install anything due to logic bug

Changed the logic in the installed? method in the provider/product.rb.
The grep command returns an array of items matching the regex.
In the event that the returning the array is not empty, then the product must be installed.
