### PR TITLE
[COOK-3372] unzip webpi if webpi executable doesn't exist

### DIFF
--- a/recipes/install-zip.rb
+++ b/recipes/install-zip.rb
@@ -38,7 +38,6 @@ end
 windows_zipfile "webpicmdline" do
   path installdir
   source "#{Chef::Config[:file_cache_path]}/#{file_name}"
-  action :nothing
   not_if { ::File.exists?("#{node['webpi']['home']}/WebpiCmd.exe") }
 end
 


### PR DESCRIPTION
Original pull request from HH here:

```
https://github.com/opscode-cookbooks/webpi/pull/4
```

The not_if guard protects us from unzipping this on every run and
removing the `action :nothing` ensure that the file will get unzip on
the next run even if the previous run failed before it could be
unzipped but after it was downloaded.
