### PR TITLE
Fixed COOK-3832

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,8 +22,10 @@ default['webpi']['install_method'] = "msi" # msi or zip
 
 case  node['kernel']['machine']
 when "x86_64"
+  default['webpi']['msi_checksum'] = '63eb18348d9299a575124b55cb86b748abeb971b869d8ce14b7c4bec4b76c5f6'
   default['webpi']['msi'] = "http://download.microsoft.com/download/7/0/4/704CEB4C-9F42-4962-A2B0-5C84B0682C7A/WebPlatformInstaller_amd64_en-US.msi"
 when /i[3-6]86/
+  default['webpi']['msi_checksum'] = '9c29ed64a57358997597cbc9c876e4828c706090cc31f6ab18590d1170b660de'
   default['webpi']['msi'] = "http://download.microsoft.com/download/7/0/4/704CEB4C-9F42-4962-A2B0-5C84B0682C7A/WebPlatformInstaller_x86_en-US.msi"
 end
 

--- a/recipes/install-msi.rb
+++ b/recipes/install-msi.rb
@@ -20,16 +20,9 @@
 
 include_recipe "windows"
 
-#msi bug workaround
-msi_file = ::File.join( Chef::Config[:file_cache_path], "wpi.msi" )
+msi_file = cached_file(node['webpi']['msi'], node['webpi']['msi_checksum'])
 
 # Do this stuff at compile time so we can build the path and use the exe on this run for the LWRP
-remote_file "msi" do
-  path msi_file
-  source node['webpi']['msi']
-  action :nothing
-end.run_action(:create)
-
 windows_package node['webpi']['msi_package_name'] do
   source msi_file
   action :nothing


### PR DESCRIPTION
Added checksum default attributes for both x64 and x86 MSI files. Use windows cookbook cached_file method which only downloads files if they don't exist or exist with the wrong checksum - this avoids unnecessary downloads on subsequent runs.
