### PR TITLE
Added ruby block to install-msi recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,14 +22,14 @@ default['webpi']['install_method'] = "msi" # msi or zip
 
 case  node['kernel']['machine']
 when "x86_64"
-  default['webpi']['msi_checksum'] = '63eb18348d9299a575124b55cb86b748abeb971b869d8ce14b7c4bec4b76c5f6'
-  default['webpi']['msi'] = "http://download.microsoft.com/download/7/0/4/704CEB4C-9F42-4962-A2B0-5C84B0682C7A/WebPlatformInstaller_amd64_en-US.msi"
+  default['webpi']['msi_checksum'] = 'fd3aa11da27a4698d9fd1fb61dcb5cae6d95ecf70554f0d655b0caf44b0d0ac6'
+  default['webpi']['msi'] = "http://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstaller_amd64_en-US.msi"
 when /i[3-6]86/
-  default['webpi']['msi_checksum'] = '9c29ed64a57358997597cbc9c876e4828c706090cc31f6ab18590d1170b660de'
-  default['webpi']['msi'] = "http://download.microsoft.com/download/7/0/4/704CEB4C-9F42-4962-A2B0-5C84B0682C7A/WebPlatformInstaller_x86_en-US.msi"
+  default['webpi']['msi_checksum'] = '4277d5f72f60dfda6d5c8f750f99fe963e0ed44add73e7440fda1bc05b510d25'
+  default['webpi']['msi'] = "http://download.microsoft.com/download/C/F/F/CFF3A0B8-99D4-41A2-AE1A-496C08BEB904/WebPlatformInstaller_x86_en-US.msi"
 end
 
-default['webpi']['msi_package_name'] = "Microsoft Web Platform Installer 4.6"
+default['webpi']['msi_package_name'] = "Microsoft Web Platform Installer 5.0"
 
 default['webpi']['url']       = 'http://download.microsoft.com/download/6/8/D/68DAB32D-10B6-461D-8FF5-43CE9BDA6CE5/WebPICMD.zip'
 default['webpi']['checksum']  = '7bef8162b983fc83584016dbe0d3b0070a54eca44155f532b65a3ded7a59dccd'

--- a/recipes/install-msi.rb
+++ b/recipes/install-msi.rb
@@ -28,14 +28,18 @@ windows_package node['webpi']['msi_package_name'] do
   action :nothing
 end.run_action(:install)
 
-# MSI manage PATH
-if system("where WebpiCmd.exe 2>&1 > NUL")
-  node.default['webpi']['bin'] = "WebpiCmd.exe"
-elsif ::File.exists? "#{ENV['ProgramW6432']}/Microsoft/Web Platform Installer/WebpiCmd.exe"
-  node.default['webpi']['bin'] = "#{ENV['ProgramW6432']}/Microsoft/Web Platform Installer/WebpiCmd.exe"
-elsif ::File.exists? "#{ENV['ProgramFiles']}/Microsoft/Web Platform Installer/WebpiCmd.exe"
-  node.default['webpi']['bin'] = "#{ENV['ProgramFiles']}/Microsoft/Web Platform Installer/WebpiCmd.exe"
-else
-  Chef::Log.error "Unable to find Webpi executable"
-  raise "WebpiCmd.exe can't be found"
+ruby_block 'verify installation' do
+  block do
+    # MSI manage PATH
+    if system("where WebpiCmd.exe 2>&1 > NUL")
+      node.default['webpi']['bin'] = "WebpiCmd.exe"
+    elsif ::File.exists? "#{ENV['ProgramW6432']}/Microsoft/Web Platform Installer/WebpiCmd.exe"
+      node.default['webpi']['bin'] = "#{ENV['ProgramW6432']}/Microsoft/Web Platform Installer/WebpiCmd.exe"
+    elsif ::File.exists? "#{ENV['ProgramFiles']}/Microsoft/Web Platform Installer/WebpiCmd.exe"
+      node.default['webpi']['bin'] = "#{ENV['ProgramFiles']}/Microsoft/Web Platform Installer/WebpiCmd.exe"
+    else
+      Chef::Log.error "Unable to find Webpi executable"
+      raise "WebpiCmd.exe can't be found"
+    end
+  end
 end


### PR DESCRIPTION
Surrounded the verification block at the end of install-msi with a ruby block, since this can cause chefspec to fail if webpi is not installed on the machine running the tests.

https://tickets.opscode.com/browse/COOK-4599