### PR TITLE
Add application support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ Attributes
 
 Resource/Provider
 -----------------
+### webpi_application
+#### Actions
+- :install: install an application using WebpiCmdLine
+
+#### Attribute Parameters
+- product_id: name attribute. Specifies the ID of an application to install.
+- accept_eula: specifies that WebpiCmdLine should auto-accept EULAs. Default is false.
+- mysql_password: Specifies the password to use for MySQL when installing applications that use MySQL.
+- sql_password: Specifies the password to use for SQL server when installing applications that use SQL server.
+
+#### Examples
+Install WordPress (Will install PHP, IIS 8 and MySQL too)
+```ruby
+webpi_application 'WordPress' do
+  accept_eula true
+  mysql_password 'some_password'
+  action :install
+end
+```
+
 ### webpi_product
 #### Actions
 - :install: install a product using WebpiCmdLine

--- a/providers/application.rb
+++ b/providers/application.rb
@@ -1,0 +1,76 @@
+#
+# Author:: Willem Meints (willem.meints@infosupport.com)
+# Cookbook Name:: webpi
+# Provider:: application
+#
+# Copyright:: 2011, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/mixin/shell_out'
+
+include Chef::Mixin::ShellOut
+include Windows::Helper
+
+action :install do
+  check_installed
+
+  unless @install_list.empty?
+    cmd = "\"#{webpicmd}\" /Install"
+    cmd << " /application:#{@install_list} /suppressreboot"
+    cmd << " /accepteula" if @new_resource.accept_eula
+    cmd << " /XML:#{node['webpi']['xmlpath']}" if node['webpi']['xmlpath']
+    cmd << " /Log:#{node['webpi']['log']}"
+    cmd << " /MySQLPassword:\"#{@new_resource.mysql_password}\"" if @new_resource.mysql_password
+    cmd << " /SQLPassword:\"#{@new_resource.sql_password}\"" if @new_resource.sql_password
+
+    shell_out!(cmd, {:returns => [0,42]})
+    @new_resource.updated_by_last_action(true)
+    Chef::Log.info("#{@new_resource} added new application '#{@install_list}'")
+  else
+    Chef::Log.debug("#{@new_resource} application already exists - nothing to do")
+  end
+end
+
+private
+
+#Method checks webpi to see what's installed.
+#Then loops through each product, and if it's missing, adds it to a list to be installed
+def check_installed
+    @install_array = Array.new
+    cmd = "\"#{webpicmd}\" /List /ListOption:Installed"
+    cmd << " /XML:#{node['webpi']['xmlpath']}" if node['webpi']['xmlpath']
+    cmd_out = shell_out(cmd, {:returns => [0,42]})
+    unless cmd_out.stderr.empty?
+      Chef::Log.Info(cmd_out.stderr)
+      @install_array = @new_resource.product_id
+    else
+      @new_resource.product_id.split(",").each do |p|
+        #Example output
+        #HTTPErrors           IIS: HTTP Errors
+        #Example output returned via grep
+        #\r    \rHTTPErrors           IIS: HTTP Errors\r\ns
+        if cmd_out.stdout.lines.grep(/^\s{6}#{p}\s.*$/i).empty?
+          @install_array << p
+        end
+      end
+    end
+    @install_list = @install_array.join(",")
+end
+
+def webpicmd
+  @webpicmd ||= begin
+    node['webpi']['bin']
+  end
+end

--- a/resources/application.rb
+++ b/resources/application.rb
@@ -1,0 +1,34 @@
+#
+# Author:: Willem Meints (willem.meints@infosupport.com)
+# Cookbook Name:: webpi
+# Resource:: application
+#
+# Copyright:: 2011, Opscode, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :install
+
+default_action :install
+
+attribute :product_id, :kind_of => String, :name_attribute => true
+attribute :accept_eula, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :mysql_password, :kind_of => String
+attribute :sql_password, :kind_of => String
+
+# Covers 0.10.8 and earlier and COOK-1251
+def initialize(*args)
+  super
+  @action = :install
+end


### PR DESCRIPTION
This adds support for installing applications through the
web platform installer using the webpi_application resource.
Check the updated readme for more information.