### PR TITLE
update windows cookbook dependency pin and remove unneeded includes to default recipe in windows cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures the Microsoft Web Platform Installer (WebP
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.2.9'
 supports         'windows'
-depends          'windows', '>= 1.2.6'
+depends          'windows', '>= 1.39.0'
 
 source_url 'https://github.com/chef-cookbooks/webpi' if respond_to?(:source_url)
 issues_url 'https://github.com/chef-cookbooks/webpi/issues' if respond_to?(:issues_url)

--- a/recipes/install-msi.rb
+++ b/recipes/install-msi.rb
@@ -18,8 +18,6 @@
 # limitations under the License.
 #
 
-include_recipe 'windows'
-
 msi_file = cached_file(node['webpi']['msi'], node['webpi']['msi_checksum'])
 
 # Do this stuff at compile time so we can build the path and use the exe on this run for the LWRP

--- a/recipes/install-zip.rb
+++ b/recipes/install-zip.rb
@@ -18,8 +18,6 @@
 # limitations under the License.
 #
 
-include_recipe 'windows'
-
 file_name = ::File.basename(node['webpi']['url'])
 installdir = node['webpi']['home']
 


### PR DESCRIPTION
the webpi recipes include the windows cookbook default recipe which raises a bunch of warnings around its use of the `chef_gem` resource. However, the gems that the windows default recipe installs are not needed by webpi.