### PR TITLE
add `returns` argument to webpi_product resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Microsoft Web Platform Installer (WebPI) automates the installation of Microsoft
 #### Attribute Parameters
 - product_id: name attribute. Specifies the ID of a product to install.
 - accept_eula: specifies that WebpiCmdline should auto-accept EULAs. Default is false.
+- returns: specifies the return value(s) expected for a successful installation. Can be a single integer or array of integers.  Default is [0, 42]
 
 #### Examples
 Install IIS 7 Recommended Configuration (will install IIS 8 on Windows 2012 despite the name)
@@ -50,6 +51,16 @@ Install Windows PowerShell 2.0
 webpi_product 'PowerShell2' do
   accept_eula true
   action :install
+end
+```
+
+Install Windows Azure Powershell 1.0 (will return a 3010 exit code to signify a successful installation that requires a reboot)
+
+```ruby
+webpi_product 'WindowsAzurePowerShellGet' do
+  accept_eula true
+  action :install
+  returns 3010
 end
 ```
 

--- a/providers/product.rb
+++ b/providers/product.rb
@@ -35,7 +35,7 @@ action :install do
       cmd << ' /accepteula' if @new_resource.accept_eula
       cmd << " /XML:#{node['webpi']['xmlpath']}" if node['webpi']['xmlpath']
       cmd << " /Log:#{node['webpi']['log']}"
-      shell_out!(cmd, returns: [0, 42])
+      shell_out!(cmd, returns: @new_resource.returns)
     end
   end
 end

--- a/resources/product.rb
+++ b/resources/product.rb
@@ -23,3 +23,4 @@ default_action :install
 
 attribute :product_id, kind_of: String, name_attribute: true
 attribute :accept_eula, kind_of: [TrueClass, FalseClass], default: false
+attribute :returns, kind_of: [Integer, Array], default: [0, 42]


### PR DESCRIPTION
### Description

adds the `returns` argument to the webpi_product resource so additional return values can be specified - instead of just 0 and 42.
### Issues Resolved

have been running into some issues trying to get the "WindowsAzurePowerShellGet" module to install through the webpi_product resource because the return value is 3010 for a successful installation of that module.

```
================================================================================
  Error executing action `install` on resource 'webpi_product[WindowsAzurePowerShellGet]'
  ================================================================================

  Mixlib::ShellOut::ShellCommandFailed
  ------------------------------------
  Expected process to exit with [0, 42], but received '3010'
---- Begin output of "webpicmd.exe" /Install /products:WindowsAzurePowerShellGet /suppressreboot /accepteula /Log:C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\cache/WebPI.log ----
STDOUT: The software that you obtain using the Web Platform Installer Command Line Tool is licensed to you by its owner.  Microsoft grants you no rights for third party software.

Successfully loaded primary feed: https://go.microsoft.com/?linkid=9842185
The following software is going to be installed:
EULA: 'Microsoft Azure PowerShell', which is owned by 'Microsoft Corporation', will be downloaded from 'http://aka.ms/azure-powershellget'.
The license agreement to 'Microsoft Azure PowerShell' is available at 'http://go.microsoft.com/fwlink/?LinkId=394986'.
Accepted EULA.
Starting Installation
Started downloading products...
Started downloading: 'Microsoft Azure PowerShell'
Downloaded: 'Microsoft Azure PowerShell'
Started installing Products...
Started installing: 'Microsoft Azure PowerShell'
Install completed (SuccessRebootRequired): 'Microsoft Azure PowerShell'
Reboot is required for product WindowsAzurePowershellGet. Install SUCCESS
Beginning Reboot...
Pre-Reboot Download count: 0 Mb, 17 sec
Pre-Reboot Installation count: 362.55 Mb, 17 sec

Verifying successful installation...
Microsoft Azure PowerShell                         False
    Log Location: C:\Users\Administrator\AppData\Local\Microsoft\Web Platform Installer\logs\install\2016-05-13T16.57.31\azure-powershell.1.4.0.txt
Install of Products: REBOOT REQUIRED
   STDERR:
   ---- End output of "webpicmd.exe" /Install /products:WindowsAzurePowerShellGet /suppressreboot /accepteula /Log:C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\cache/WebPI.log ----
   Ran "webpicmd.exe" /Install /products:WindowsAzurePowerShellGet /suppressreboot /accepteula /Log:C:\Users\ADMINI~1\AppData\Local\Temp\kitchen\cache/WebPI.log returned 3010
```
