### PR TITLE
We don't need no cached file

### DIFF
--- a/recipes/install-msi.rb
+++ b/recipes/install-msi.rb
@@ -18,11 +18,10 @@
 # limitations under the License.
 #
 
-msi_file = cached_file(node['webpi']['msi'], node['webpi']['msi_checksum'])
-
 # Do this stuff at compile time so we can build the path and use the exe on this run for the LWRP
-package node['webpi']['msi_package_name'] do
-  source msi_file
+windows_package node['webpi']['msi_package_name'] do
+  source node['webpi']['msi']
+  checksum node['webpi']['msi_checksum']
   action :nothing
 end.run_action(:install)
 


### PR DESCRIPTION
The `cached_file` helper from the `windows` cookbook is no longer necessary for this use case, because `windows_package` (since about 12.4) supports installs via remote path (using `remote_file`).