### PR TITLE
fix: migrate to Policyfile and repair ci final job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
 
   integration:
     needs: "lint-unit"
-    runs-on: macos-15
+    runs-on: windows-latest
     strategy:
       matrix:
         os:
-          - windows-2016
+          - windows-latest
         suite:
           - default
       fail-fast: false
@@ -35,7 +35,7 @@ jobs:
         uses: actionshub/test-kitchen@3.0.0
         env:
           CHEF_LICENSE: accept-no-persist
-          KITCHEN_LOCAL_YAML: kitchen.yml
+          KITCHEN_LOCAL_YAML: kitchen.exec.yml
         with:
           suite: ${{ matrix.suite }}
           os: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
       - name: Install Chef
-        uses: actionshub/chef-install@6.0.0
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Kitchen Test
         uses: actionshub/test-kitchen@3.0.0
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
     runs-on: ubuntu-latest
     needs: [integration]
     steps:
-      - run: echo ${{needs.integration.outputs}}
+      - run: echo "Integration complete"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: './test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+name 'webpi'
+
+default_source :supermarket
+
+run_list 'recipe[test::default]'
+
+named_run_list :default, 'recipe[test::default]'
+
+cookbook 'webpi', path: '.'
+cookbook 'test', path: './test/cookbooks/test'

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,8 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
+# Dependency cache #
+####################
 cookbooks/*
 tmp
 
@@ -98,7 +96,6 @@ Gemfile.lock
 
 # Policyfile #
 ##############
-Policyfile.rb
 Policyfile.lock.json
 
 # Documentation #

--- a/kitchen.appveyor.yml
+++ b/kitchen.appveyor.yml
@@ -9,6 +9,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  policyfile: Policyfile.rb
   deprecations_as_errors: true
   client_rb:
     chef_license: accept
@@ -18,5 +19,5 @@ platforms:
 
 suites:
   - name: default
-    run_list:
-      - recipe[test::default]
+    provisioner:
+      named_run_list: default

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -10,6 +10,7 @@ transport:
 
 provisioner:
   name: chef_zero
+  policyfile: Policyfile.rb
   deprecations_as_errors: true
   chef_license: accept-no-persist
 
@@ -26,5 +27,5 @@ platforms:
 
 suites:
   - name: default
-    run_list:
-      - recipe[test::default]
+    provisioner:
+      named_run_list: default

--- a/recipes/install-zip.rb
+++ b/recipes/install-zip.rb
@@ -33,9 +33,8 @@ directory installdir do
   recursive true
 end
 
-archive_file 'webpicmdline' do
-  path installdir
-  source "#{Chef::Config[:file_cache_path]}/#{file_name}"
+archive_file "#{Chef::Config[:file_cache_path]}/#{file_name}" do
+  destination installdir
   action :extract
 end
 

--- a/recipes/install-zip.rb
+++ b/recipes/install-zip.rb
@@ -20,12 +20,13 @@
 
 file_name = ::File.basename(node['webpi']['url'])
 installdir = node['webpi']['home']
+zip_path = "#{Chef::Config[:file_cache_path]}/#{file_name}"
 
-remote_file "#{Chef::Config[:file_cache_path]}/#{file_name}" do
+remote_file zip_path do
   source node['webpi']['url']
   checksum node['webpi']['checksum']
   notifies :delete, "directory[#{installdir}]", :immediately
-  notifies :unzip, 'windows_zipfile[webpicmdline]', :immediately
+  notifies :extract, "archive_file[#{zip_path}]", :immediately
 end
 
 directory installdir do
@@ -33,7 +34,7 @@ directory installdir do
   recursive true
 end
 
-archive_file "#{Chef::Config[:file_cache_path]}/#{file_name}" do
+archive_file zip_path do
   destination installdir
   action :extract
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -15,3 +15,15 @@ describe 'default recipe on Windows 2016' do
     expect { :chef_run }.to_not raise_error
   end
 end
+
+describe 'webpi::install-zip' do
+  platform 'windows', '2016' do |node|
+    node.override['webpi']['install_method'] = 'zip'
+  end
+
+  let(:zip_path) { "#{Chef::Config[:file_cache_path]}/WebPICMD.zip" }
+
+  it 'extracts the downloaded WebPI command line archive' do
+    expect(chef_run.remote_file(zip_path)).to notify("archive_file[#{zip_path}]").to(:extract).immediately
+  end
+end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -4,6 +4,8 @@
 #
 # Copyright:: 2017-2019, Chef Software, Inc.
 
+node.default['webpi']['install_method'] = 'zip'
+
 include_recipe 'webpi::default'
 
 webpi_product 'PHP54' do


### PR DESCRIPTION
## Summary
- Replace Berksfile dependency resolution with Policyfile.rb
- Update ChefSpec and Kitchen to use Policyfile resolution
- Update Copilot setup to run chef install Policyfile.rb

## Verification
- chef install Policyfile.rb
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- markdownlint-cli2 "**/*.md"
- embedded rspec --format progress
- git diff --check