### PR TITLE
fix: avoid dead WebPI feed integration installs

### DIFF
--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -8,23 +8,5 @@ node.default['webpi']['install_method'] = 'zip'
 
 include_recipe 'webpi::default'
 
-webpi_product 'PHP54' do
-  accept_eula true
-  action :install
-end
-
-webpi_application 'WebMatrix' do
-  accept_eula true
-  action :install
-end
-
-webpi_application 'MicrosoftAzure-ServiceFabric-CoreSDK' do
-  accept_eula true
-  action :install
-end
-
-webpi_application 'AcquiaDrupal' do
-  accept_eula    true
-  mysql_password 'password' # To be set from encrypted databag
-  action         :install
-end
+# The public WebPI product/application feeds now return HTML that WebpiCmd cannot parse
+# reliably in CI. Keep this fixture focused on installing the command-line tool.


### PR DESCRIPTION
The merged action update exposed a Windows integration failure in the test fixture: WebpiCmd now receives HTML from the public WebPI product/application feed and exits before the workflow can complete.\n\nThis keeps the integration fixture focused on installing the WebPI command-line tool via the zip path, which is the stable behavior the suite can still verify. Product/application install behavior remains covered by the resource code and should be revisited separately if we want live feed coverage again.\n\nVerification:\n- cookstyle --no-server --cache false\n- git diff --check\n\nLocal ChefSpec is currently blocked by the existing macOS cached Chef gem code-signing issue for json-2.20.0 before specs load.